### PR TITLE
improve error reporting in cctray parsing

### DIFF
--- a/fixtures/vcr_cassettes/no_projects.yml
+++ b/fixtures/vcr_cassettes/no_projects.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.travis-ci.org/repositories/markryall/chicanery/cc.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - ! '*/*'
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-origin:
+      - ! '*'
+      access-control-expose-headers:
+      - Content-Type, Cache-Control, Expires, Etag, Last-Modified
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json;charset=utf-8
+      date:
+      - Sat, 15 Dec 2012 02:39:04 GMT
+      etag:
+      - ! '"aa451983b94cbec99aa94346f358b5b0"'
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000
+      vary:
+      - Accept,Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public
+      x-oauth-scopes:
+      - public
+      content-length:
+      - '217'
+      connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! "Nothing here but us chickens"
+    http_version: '1.1'
+  recorded_at: Sat, 15 Dec 2012 02:39:09 GMT
+recorded_with: VCR 2.3.0

--- a/fixtures/vcr_cassettes/redirect.yml
+++ b/fixtures/vcr_cassettes/redirect.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.travis-ci.org/repositories/markryall/chicanery/cc.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - ! '*/*'
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Redirect
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-origin:
+      - ! '*'
+      access-control-expose-headers:
+      - Content-Type, Cache-Control, Expires, Etag, Last-Modified
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json;charset=utf-8
+      date:
+      - Sat, 15 Dec 2012 02:39:04 GMT
+      etag:
+      - ! '"aa451983b94cbec99aa94346f358b5b0"'
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000
+      vary:
+      - Accept,Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public
+      x-oauth-scopes:
+      - public
+      content-length:
+      - '217'
+      connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! "hhh"
+    http_version: '1.1'
+  recorded_at: Sat, 15 Dec 2012 02:39:09 GMT
+recorded_with: VCR 2.3.0

--- a/spec/chicanery/cctray_spec.rb
+++ b/spec/chicanery/cctray_spec.rb
@@ -52,4 +52,17 @@ describe Chicanery::Cctray do
       }
     end
   end
+  
+  it 'should complain if there are no jobs in response' do
+     VCR.use_cassette('no_projects') do
+       expect{server.jobs}.to raise_error "could not find any jobs in response: [Nothing here but us chickens]"
+     end
+  end
+  
+  it 'should complain if it gets a non 2xx response' do
+     VCR.use_cassette('redirect') do
+       expect{server.jobs}.to raise_error Net::HTTPRetriableError
+     end
+  end  
+  
 end


### PR DESCRIPTION
I had some trouble figuring out why blinky was green working when watching a travis url that had a failing build.

It turned out I had the url slightly wrong and it was returning a 301 with an empty body - which was interpreted as 0 jobs and hence "no failures"

I've made it complain bitterly if it gets a non 200 response or if the body has no jobs
